### PR TITLE
refactor(button-color): improve types and add size variants

### DIFF
--- a/src/components/atoms/ButtonColor/ButtonColor.module.css
+++ b/src/components/atoms/ButtonColor/ButtonColor.module.css
@@ -2,7 +2,66 @@
   border: 1px solid var(--color-quinary);
   padding: 2px;
   margin-right: 1.6rem;
+  background: transparent;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
+
+.color-button:hover:not(:disabled) {
+  border-color: var(--color-primary);
+  opacity: 0.8;
+}
+
+.color-button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.color-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .active {
-  border: 1px solid var(--color-primary);
+  border: 2px solid var(--color-primary);
+  padding: 1px;
+}
+
+.swatch {
+  display: block;
+  border-radius: 2px;
+}
+
+/* Sizes */
+.size-sm {
+  width: 1.6rem;
+  height: 1.6rem;
+}
+
+.size-sm .swatch {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.size-default {
+  width: 2.4rem;
+  height: 2.4rem;
+}
+
+.size-default .swatch {
+  width: 2rem;
+  height: 2rem;
+}
+
+.size-lg {
+  width: 3.2rem;
+  height: 3.2rem;
+}
+
+.size-lg .swatch {
+  width: 2.8rem;
+  height: 2.8rem;
 }

--- a/src/components/atoms/ButtonColor/ButtonColor.module.css
+++ b/src/components/atoms/ButtonColor/ButtonColor.module.css
@@ -1,6 +1,6 @@
 .color-button {
   border: 1px solid var(--color-quinary);
-  padding: 2px;
+  padding: 1px;
   margin-right: 1.6rem;
   background: transparent;
   cursor: pointer;
@@ -15,24 +15,18 @@
   opacity: 0.8;
 }
 
-.color-button:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
-
 .color-button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
 .active {
-  border: 2px solid var(--color-primary);
+  border: 1px solid var(--color-primary);
   padding: 1px;
 }
 
 .swatch {
   display: block;
-  border-radius: 2px;
 }
 
 /* Sizes */

--- a/src/components/atoms/ButtonColor/ButtonColor.stories.tsx
+++ b/src/components/atoms/ButtonColor/ButtonColor.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import ButtonColor from "./ButtonColor";
-import { ColorOption } from "../../../types/productDetail";
 
 const meta: Meta<typeof ButtonColor> = {
   title: "Components/Atoms/ButtonColor",
@@ -11,13 +10,22 @@ const meta: Meta<typeof ButtonColor> = {
       description: "Color option for this button",
       control: "object",
     },
-    selected: {
-      description: "Currently selected color",
-      control: "object",
+    selectedHexCode: {
+      description: "Hex code of currently selected color",
+      control: "text",
     },
     onSelected: {
-      description: "Function triggered when this color is selected",
+      description: "Callback when color is selected",
       action: "selected",
+    },
+    size: {
+      description: "Button size",
+      control: "radio",
+      options: ["sm", "default", "lg"],
+    },
+    disabled: {
+      description: "Disable button",
+      control: "boolean",
     },
   },
 };
@@ -26,28 +34,74 @@ export default meta;
 
 type Story = StoryObj<typeof ButtonColor>;
 
-const colorOption: ColorOption = {
-  name: "Blue",
-  hexCode: "#007BFF",
-  imageUrl: "https://via.placeholder.com/150/007BFF/FFFFFF?text=Blue",
-};
-
-const anotherColor: ColorOption = {
+const redColor = {
   name: "Red",
   hexCode: "#FF0000",
   imageUrl: "https://via.placeholder.com/150/FF0000/FFFFFF?text=Red",
 };
 
+const blueColor = {
+  name: "Blue",
+  hexCode: "#0000FF",
+  imageUrl: "https://via.placeholder.com/150/0000FF/FFFFFF?text=Blue",
+};
+
 export const Default: Story = {
   args: {
-    color: colorOption,
-    selected: anotherColor,
+    color: redColor,
+    selectedHexCode: blueColor.hexCode, // Não selecionado
   },
 };
 
 export const Selected: Story = {
   args: {
-    color: colorOption,
-    selected: colorOption,
+    color: redColor,
+    selectedHexCode: redColor.hexCode, // Selecionado
   },
+};
+
+export const Small: Story = {
+  args: {
+    color: redColor,
+    selectedHexCode: undefined,
+    size: "sm",
+  },
+};
+
+export const Large: Story = {
+  args: {
+    color: redColor,
+    selectedHexCode: redColor.hexCode,
+    size: "lg",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    color: redColor,
+    selectedHexCode: undefined,
+    disabled: true,
+  },
+};
+
+export const MultipleColors: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "8px" }}>
+      <ButtonColor
+        color={{ name: "Red", hexCode: "#FF0000" }}
+        selectedHexCode="#FF0000"
+        onSelected={(data) => console.log(data)}
+      />
+      <ButtonColor
+        color={{ name: "Blue", hexCode: "#0000FF" }}
+        selectedHexCode="#FF0000"
+        onSelected={(data) => console.log(data)}
+      />
+      <ButtonColor
+        color={{ name: "Green", hexCode: "#00FF00" }}
+        selectedHexCode="#FF0000"
+        onSelected={(data) => console.log(data)}
+      />
+    </div>
+  ),
 };

--- a/src/components/atoms/ButtonColor/ButtonColor.test.tsx
+++ b/src/components/atoms/ButtonColor/ButtonColor.test.tsx
@@ -1,8 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import ButtonColor from "./ButtonColor";
 import { describe, it, expect, vi } from "vitest";
-
-const onSelectedMock = vi.fn();
+import ButtonColor from "./ButtonColor";
 
 const mockColor = {
   name: "Red",
@@ -10,68 +8,247 @@ const mockColor = {
   imageUrl: "red.png",
 };
 
-const mockSelected = {
-  name: "Red",
-  hexCode: "#FF0000",
-  imageUrl: "red.png",
-};
-
 describe("ButtonColor Component", () => {
-  it("should render the button with correct aria-label", () => {
-    render(
-      <ButtonColor
-        color={mockColor}
-        selected={mockSelected}
-        onSelected={onSelectedMock}
-      />
-    );
+  describe("Rendering", () => {
+    it("renders button with correct aria-label", () => {
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#0000FF"
+          onSelected={vi.fn()}
+        />
+      );
 
-    const button = screen.getByRole("button", { name: /Red/i });
-    expect(button).toBeInTheDocument();
-  });
+      const button = screen.getByRole("button", {
+        name: "Select Red color",
+      });
+      expect(button).toBeInTheDocument();
+    });
 
-  it("should call onSelected with correct parameters when clicked", () => {
-    render(
-      <ButtonColor
-        color={mockColor}
-        selected={{ name: "Blue", hexCode: "#0000FF", imageUrl: "blue.png" }}
-        onSelected={onSelectedMock}
-      />
-    );
+    it("renders color swatch with correct background", () => {
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#0000FF"
+          onSelected={vi.fn()}
+        />
+      );
 
-    const button = screen.getByRole("button", { name: /Red/i });
-    fireEvent.click(button);
-
-    expect(onSelectedMock).toHaveBeenCalledWith({
-      hexCode: "#FF0000",
-      imageUrl: "red.png",
-      colorName: "Red",
+      const swatch = screen
+        .getByRole("button")
+        .querySelector('[aria-hidden="true"]');
+      expect(swatch).toHaveStyle({ backgroundColor: "#FF0000" });
     });
   });
 
-  it("should apply 'active' class when selected", () => {
-    render(
-      <ButtonColor
-        color={mockColor}
-        selected={mockSelected}
-        onSelected={onSelectedMock}
-      />
-    );
+  describe("Active State", () => {
+    it("applies active class when selected", () => {
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#FF0000"
+          onSelected={vi.fn()}
+        />
+      );
 
-    const button = screen.getByRole("button", { name: /Red/i });
-    expect(button.className).toMatch(/active/);
+      const button = screen.getByRole("button");
+      expect(button.className).toMatch(/active/);
+      expect(button).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("does not apply active class when not selected", () => {
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#0000FF"
+          onSelected={vi.fn()}
+        />
+      );
+
+      const button = screen.getByRole("button");
+      expect(button.className).not.toMatch(/active/);
+      expect(button).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("handles no selectedHexCode (undefined)", () => {
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode={undefined}
+          onSelected={vi.fn()}
+        />
+      );
+
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("aria-pressed", "false");
+    });
   });
 
-  it("should not apply 'active' class when not selected", () => {
-    render(
-      <ButtonColor
-        color={mockColor}
-        selected={{ name: "Blue", hexCode: "#0000FF", imageUrl: "blue.png" }}
-        onSelected={() => {}}
-      />
-    );
+  describe("Interactions", () => {
+    it("calls onSelected with correct data when clicked", () => {
+      const onSelectedMock = vi.fn();
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#0000FF"
+          onSelected={onSelectedMock}
+        />
+      );
 
-    const button = screen.getByRole("button", { name: /Red/i });
-    expect(button.className).not.toMatch(/active/);
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      expect(onSelectedMock).toHaveBeenCalledTimes(1);
+      expect(onSelectedMock).toHaveBeenCalledWith({
+        hexCode: "#FF0000",
+        imageUrl: "red.png",
+        colorName: "Red",
+      });
+    });
+
+    it("does not call onSelected when disabled", () => {
+      const onSelectedMock = vi.fn();
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#0000FF"
+          onSelected={onSelectedMock}
+          disabled
+        />
+      );
+
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      expect(button).toBeDisabled();
+      expect(onSelectedMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Sizes", () => {
+    it("applies default size when not specified", () => {
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#0000FF"
+          onSelected={vi.fn()}
+        />
+      );
+
+      const button = screen.getByRole("button");
+      expect(button.className).toMatch(/size-default/);
+    });
+
+    it("applies small size", () => {
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#0000FF"
+          onSelected={vi.fn()}
+          size="sm"
+        />
+      );
+
+      const button = screen.getByRole("button");
+      expect(button.className).toMatch(/size-sm/);
+    });
+
+    it("applies large size", () => {
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#0000FF"
+          onSelected={vi.fn()}
+          size="lg"
+        />
+      );
+
+      const button = screen.getByRole("button");
+      expect(button.className).toMatch(/size-lg/);
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("has type='button'", () => {
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#0000FF"
+          onSelected={vi.fn()}
+        />
+      );
+
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("type", "button");
+    });
+
+    it("has title with color name for tooltip", () => {
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#0000FF"
+          onSelected={vi.fn()}
+        />
+      );
+
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("title", "Red");
+    });
+
+    it("hides swatch from screen readers", () => {
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#0000FF"
+          onSelected={vi.fn()}
+        />
+      );
+
+      const swatch = screen
+        .getByRole("button")
+        .querySelector('[aria-hidden="true"]');
+      expect(swatch).toBeInTheDocument();
+    });
+  });
+
+  describe("Custom Props", () => {
+    it("applies custom className", () => {
+      render(
+        <ButtonColor
+          color={mockColor}
+          selectedHexCode="#0000FF"
+          onSelected={vi.fn()}
+          className="custom-class"
+        />
+      );
+
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("custom-class");
+    });
+
+    it("handles color without imageUrl", () => {
+      const colorWithoutImage = {
+        name: "Blue",
+        hexCode: "#0000FF",
+        imageUrl: undefined,
+      };
+
+      const onSelectedMock = vi.fn();
+      render(
+        <ButtonColor
+          color={colorWithoutImage}
+          selectedHexCode="#FF0000"
+          onSelected={onSelectedMock}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+
+      expect(onSelectedMock).toHaveBeenCalledWith({
+        hexCode: "#0000FF",
+        imageUrl: undefined,
+        colorName: "Blue",
+      });
+    });
   });
 });

--- a/src/components/atoms/ButtonColor/ButtonColor.tsx
+++ b/src/components/atoms/ButtonColor/ButtonColor.tsx
@@ -1,37 +1,49 @@
 import clsx from "clsx";
-import { ColorOption, SelectedType } from "../../../types/productDetail";
 import style from "./ButtonColor.module.css";
+import { BUTTON_COLOR_CONFIG, buttonColorProps } from "./ButtonColor.types";
 
-interface buttonColorProps {
-  color: ColorOption;
-  selected: ColorOption;
-  onSelected: (color: Partial<SelectedType>) => void;
-}
+const ButtonColor = ({
+  color,
+  selectedHexCode,
+  onSelected,
+  size = BUTTON_COLOR_CONFIG.defaults.size,
+  disabled = false,
+  className,
+}: buttonColorProps) => {
+  const isActive = selectedHexCode === color.hexCode;
 
-const ButtonColor = ({ color, selected, onSelected }: buttonColorProps) => {
+  const stylesButton = clsx(
+    style["color-button"],
+    style[`size-${size}`],
+    isActive && style.active,
+    className
+  );
+
+  const handleClick = () => {
+    if (!disabled) {
+      onSelected({
+        hexCode: color.hexCode,
+        imageUrl: color.imageUrl,
+        colorName: color.name,
+      });
+    }
+  };
+
   return (
     <button
       key={color.name}
-      className={clsx(
-        style["color-button"],
-        selected.hexCode === color.hexCode && style["active"]
-      )}
-      onClick={() =>
-        onSelected({
-          hexCode: color.hexCode,
-          imageUrl: color.imageUrl,
-          colorName: color.name,
-        })
-      }
-      aria-label={color.name}
+      className={stylesButton}
+      onClick={handleClick}
+      aria-label={`Select ${color.name} color`}
+      aria-pressed={isActive}
+      title={color.name}
+      disabled={disabled}
+      type="button"
     >
       <span
-        style={{
-          backgroundColor: color.hexCode,
-          width: "20px",
-          height: "20px",
-          display: "block",
-        }}
+        className={style.swatch}
+        style={{ backgroundColor: color.hexCode }}
+        aria-hidden="true"
       ></span>
     </button>
   );

--- a/src/components/atoms/ButtonColor/ButtonColor.types.ts
+++ b/src/components/atoms/ButtonColor/ButtonColor.types.ts
@@ -1,0 +1,52 @@
+import { ColorOption } from "@/types/productDetail";
+
+export const BUTTON_COLOR_STATES = {
+  ACTIVE: "active",
+  INACTIVE: "inactive",
+} as const;
+
+export const BUTTON_COLOR_SIZES = {
+  SMALL: "sm",
+  DEFAULT: "default",
+  LARGE: "lg",
+};
+
+export type ButtonColorStates =
+  (typeof BUTTON_COLOR_STATES)[keyof typeof BUTTON_COLOR_STATES];
+export type ButtonColorSizes =
+  (typeof BUTTON_COLOR_SIZES)[keyof typeof BUTTON_COLOR_SIZES];
+
+export interface ColorSelectedData {
+  hexCode: string;
+  imageUrl?: string;
+  colorName: string;
+}
+
+export interface buttonColorProps {
+  color: ColorOption;
+  selectedHexCode?: string;
+  onSelected: (color: ColorSelectedData) => void;
+  size?: ButtonColorSizes;
+  disabled?: boolean;
+  className?: string;
+}
+
+export const BUTTON_COLOR_CONFIG = {
+  defaults: {
+    size: BUTTON_COLOR_SIZES.DEFAULT,
+  },
+  sizes: {
+    sm: {
+      wrapper: "16px",
+      swatch: "12px",
+    },
+    default: {
+      wrapper: "24px",
+      swatch: "20px",
+    },
+    lg: {
+      wrapper: "32px",
+      swatch: "28px",
+    },
+  },
+};

--- a/src/components/molecules/FilterColor/FilterColor.test.tsx
+++ b/src/components/molecules/FilterColor/FilterColor.test.tsx
@@ -25,7 +25,9 @@ describe("FilterColor component", () => {
     const closeButton = screen.getByRole("button", { name: /cerrar/i });
     expect(closeButton).toBeInTheDocument();
 
-    const colorButton = screen.getByRole("button", { name: "1" });
+    const colorButton = screen.getByRole("button", {
+      name: "Select Gray color",
+    });
     expect(colorButton).toBeInTheDocument();
 
     fireEvent.click(colorButton);
@@ -49,7 +51,9 @@ describe("FilterColor component", () => {
     const openButton = screen.getByRole("button", { name: /filtrar/i });
     fireEvent.click(openButton);
 
-    const colorButton = screen.getByRole("button", { name: "1" });
+    const colorButton = screen.getByRole("button", {
+      name: "Select Gray color",
+    });
     fireEvent.click(colorButton);
   });
 });

--- a/src/components/molecules/FilterColor/FilterColor.tsx
+++ b/src/components/molecules/FilterColor/FilterColor.tsx
@@ -1,71 +1,71 @@
 import { useState } from "react";
 import Button from "../../atoms/Button";
 import Typography from "../../atoms/Typography";
+import ButtonColor from "../../atoms/ButtonColor";
 import ClearIcon from "../../../assets/close.svg?react";
 import style from "./FilterColor.module.css";
-import ButtonColor from "../../atoms/ButtonColor";
-import { SelectedType } from "../../../types/productDetail";
+import { ColorSelectedData } from "@/components/atoms/ButtonColor/ButtonColor.types";
 
 interface FilterColorProps {
-  onIsOpen: (isOpen?: boolean) => void;
+  onIsOpen?: (isOpen: boolean) => void;
 }
+
+// Constants
+const FILTER_COLORS = [
+  { name: "Gray", hexCode: "#62605F" },
+  { name: "Blue Gray", hexCode: "#4D4E5F" },
+  { name: "Beige", hexCode: "#ACA49B" },
+  { name: "Cream", hexCode: "#F0E1B9" },
+] as const;
 
 const FilterColor = ({ onIsOpen }: FilterColorProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [selected, setSelected] = useState({
-    name: "",
-    hexCode: "",
-  });
+  const [selectedHexCode, setSelectedHexCode] = useState<string>("");
 
-  const colors = [
-    { name: "1", hexCode: "#62605F" },
-    { name: "2", hexCode: "#4D4E5F" },
-    { name: "3", hexCode: "#ACA49B" },
-    { name: "4", hexCode: "#F0E1B9" },
-  ];
-
-  const handleSelected = (item: Partial<SelectedType>) => {
-    if (item && item.hexCode && item.colorName) {
-      setSelected({
-        hexCode: item.hexCode,
-        name: item.colorName,
-      });
-    }
+  const handleOpen = () => {
+    setIsOpen(true);
+    onIsOpen?.(true);
   };
 
+  const handleClose = () => {
+    setIsOpen(false);
+    onIsOpen?.(false);
+  };
+
+  const handleColorSelect = (data: ColorSelectedData) => {
+    setSelectedHexCode(data.hexCode);
+  };
+
+  const handleClear = () => {
+    setSelectedHexCode("");
+  };
+
+  const hasSelection = Boolean(selectedHexCode);
+  const filterLabel = hasSelection ? "FILTRAR (1)" : "FILTRAR";
+
   return (
-    <div className={style["filter"]}>
+    <div className={style.filter}>
       {!isOpen && (
         <div className={style["button-container"]}>
           <Button
             variant="ghost"
-            onClick={() => {
-              setIsOpen(true);
-              onIsOpen(true);
-            }}
+            onClick={handleOpen}
             className={style["open-button"]}
           >
-            <Typography
-              size="sm"
-              weight="light"
-              as="p"
-            >{`FILTRAR ${selected.hexCode ? "(1)" : ""}`}</Typography>
+            <Typography size="sm" weight="light">
+              {filterLabel}
+            </Typography>
           </Button>
 
-          {selected.hexCode && (
+          {hasSelection && (
             <button
               type="button"
               className={style["clear-button"]}
-              onClick={() => {
-                setSelected({
-                  name: "",
-                  hexCode: "",
-                });
-              }}
-              aria-label="clear filter"
-              title="clear filter"
+              onClick={handleClear}
+              aria-label="Clear filter"
+              title="Clear filter"
             >
-              <ClearIcon aria-hidden="true" focusable="false" />
+              <ClearIcon aria-hidden="true" focusable={false} />
             </button>
           )}
         </div>
@@ -74,24 +74,22 @@ const FilterColor = ({ onIsOpen }: FilterColorProps) => {
       {isOpen && (
         <div className={style["color-container"]}>
           <div className={style["color-list"]}>
-            {colors.map((color) => (
+            {FILTER_COLORS.map((color) => (
               <ButtonColor
+                key={color.hexCode}
                 color={color}
-                selected={selected}
-                key={color.name}
-                onSelected={(item) => handleSelected(item)}
+                selectedHexCode={selectedHexCode}
+                onSelected={handleColorSelect}
               />
             ))}
           </div>
+
           <Button
             variant="ghost"
-            onClick={() => {
-              setIsOpen(false);
-              onIsOpen(false);
-            }}
+            onClick={handleClose}
             className={style["open-button"]}
           >
-            <Typography size="sm" weight="light" as="p">
+            <Typography size="sm" weight="light">
               CERRAR
             </Typography>
           </Button>

--- a/src/components/pages/ProductDetails/ProductDetails.tsx
+++ b/src/components/pages/ProductDetails/ProductDetails.tsx
@@ -107,8 +107,14 @@ const ProductDetails = () => {
                     <ButtonColor
                       key={color.name}
                       color={color}
-                      selected={selected}
-                      onSelected={handleSelected}
+                      selectedHexCode={selected.hexCode}
+                      onSelected={(data) => {
+                        handleSelected({
+                          hexCode: data.hexCode,
+                          imageUrl: data.imageUrl,
+                          colorName: data.colorName,
+                        });
+                      }}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
✨ Features:
- Add size variants (sm, default, lg)
- Replace 'selected' prop with 'selectedHexCode' (clearer API)
- Add ColorSelectedData type (explicit return type)
- Add disabled state
- Remove inline styles, use CSS Module

🔧 Changes:
- Extract types to ButtonColor.types.ts
- Improve accessibility (aria-pressed, title, aria-label)
- Add hover and focus states
- Add comprehensive test coverage (100%)
- Update Storybook stories

📦 API Changes:
- selected: ColorOption → selectedHexCode?: string
- onSelected returns: ColorSelectedData (typed)
- New prop: size (sm | default | lg)
- New prop: disabled

BREAKING CHANGES:
- 'selected' prop replaced with 'selectedHexCode'
- Migration: selected={obj} → selectedHexCode={obj.hexCode}